### PR TITLE
chore(pre-align): align heading structure (release-notes.md) with ko

### DIFF
--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,7 +1,10 @@
-## Network > Release Notes
+<a id="network-release-notes"></a>
+## Network > Release Notes { #network-release-notes }
 
-### May 27, 2026
+<a id="may-27-2026"></a>
+### May 27, 2026 { #may-27-2026 }
 
+<a id="may-27-2026-added-features"></a>
 #### Added Features
 
 ##### Network Interface
@@ -14,6 +17,7 @@
 	* Load Balancer (DSR) is available only in the Korea (Pyeongchon) and Korea (Pangyo) regions.
 * See [Load Balancer (DSR) Console User Guide](/Network/Load%20Balancer(DSR)/en/console-guide/).
 
+<a id="may-27-2026-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
@@ -26,21 +30,26 @@
     * The network path that a packet traversed (VPC Local, Internet Gateway, VPN Gateway, VPC Peering, Region Peering, Project Peering, Service Gateway) can be viewed as an integer value.
     * See [Flow Log Overview](/Network/Flow%20Log/en/overview/).
 
+<a id="may-27-2026-may-27-2026-feature-updates"></a>
 #### Feature Updates
 
 ##### VPC
 * The internal traffic handling method for VPCs has been partially changed to support network service integration. This change applies to newly created VPCs.
 
-### April 14, 2026
+<a id="april-14-2026"></a>
+### April 14, 2026 { #april-14-2026 }
 
+<a id="april-14-2026-added-features"></a>
 #### Added Features
 
 ##### DNS Plus
 * Added API v2.0
     * Added support for User Access Key tokens.
 
-### November 25, 2025
+<a id="november-25-2025"></a>
+### November 25, 2025 { #november-25-2025 }
 
+<a id="november-25-2025-added-features"></a>
 #### Added Features
 
 ##### VPN Gateway
@@ -56,13 +65,25 @@
 * Added the feature to configure custom response per listener.
 * Added the feature to enable/disable X-Forwarded-* header.
 
+<a id="november-25-2025-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer 
 * Added the feature to register/manage multiple SSL certificates in the console.
 
-### August 26, 2025
+<a id="november-25-2025-1"></a>
+#### Feature Changes
 
+<!-- TODO: translate body -->
+
+##### DNS Plus
+
+<!-- TODO: translate body -->
+
+<a id="august-26-2025"></a>
+### August 26, 2025 { #august-26-2025 }
+
+<a id="august-26-2025-added-features"></a>
 #### Added Features
 
 ##### VPN Gateway
@@ -77,8 +98,10 @@
 ##### Load Balancer
 * Added support for checking metrics such as the Load Balancer's CPU usage, listener-level statistics, and socket connection status with the Cloud Monitoring service.
 
-### May 27, 2025
+<a id="may-27-2025"></a>
+### May 27, 2025 { #may-27-2025 }
 
+<a id="may-27-2025-added-features"></a>
 #### Added Features
 
 ##### NAT Gateway
@@ -103,21 +126,26 @@
 ##### Flow Log
 * Added the feature to create Flow Logs for network interfaces of Region peering gateway, Project peering gateway, and Colocation gateway.
 
+<a id="may-27-2025-feature-updates"></a>
 #### Feature Updates
 ##### Flow Log
 * Improved that you can freely edit the folder and file names when saving Flow Log files to OBS.
 
 
-### April 29, 2025
+<a id="april-29-2025"></a>
+### April 29, 2025 { #april-29-2025 }
 
+<a id="april-29-2025-feature-updates"></a>
 #### Feature Updates
 
 ##### DNS Plus
 * Changed the minimum value of the recordset TTL from 1 to 10.
 
 
-### March 4, 2025
+<a id="march-4-2025"></a>
+### March 4, 2025 { #march-4-2025 }
 
+<a id="march-4-2025-feature-updates"></a>
 #### Feature Updates
 
 ##### Service Gateway
@@ -136,8 +164,10 @@
 * Added the feature to change the CIDR, gateway entry for a route.
 
 
-### November 26, 2024
+<a id="november-26-2024"></a>
+### November 26, 2024 { #november-26-2024 }
 
+<a id="november-26-2024-feature-updates"></a>
 #### Feature Updates
 
 ##### Peering Gateway
@@ -148,70 +178,150 @@
 * Improved to allow users to select only the statistical information items that they want to record from the ones supported by Flow Log. For the supported statistical items, see [Flowlog Overview](/Network/Flow%20Log/en/overview/).
 
 
+<a id="network-release-notes-1"></a>
+### August 27, 2024 { #network-release-notes-1 }
+
+<!-- TODO: translate body -->
+
+<a id="network-release-notes-1-1"></a>
+#### Added Features
+
+<!-- TODO: translate body -->
+
+##### Flow Log
+
+<!-- TODO: translate body -->
+
+##### Routing
+
+<!-- TODO: translate body -->
+
+##### VPN Gateway
+
+<!-- TODO: translate body -->
+
+<a id="network-release-notes-1-2"></a>
+#### Feature Updates
+
+<!-- TODO: translate body -->
+
+##### Load Balancer
+
+<!-- TODO: translate body -->
+
+##### Region Peering
+
+<!-- TODO: translate body -->
+
+##### Transit Hub
+
+<!-- TODO: translate body -->
+
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (Duplicate 'Flow Log' under t47; no corresponding ko heading (k51 already matched to t49); belongs to missing 2024.08.27 section) -->
 ##### Flow Log
 * Added the Flow Log service. Flow Log allows you to collect and store information about IP traffic sent to and received from a network interface.
     * Flow Log is only available in the Korea (Pyeongchon) region and Korea (Pangyo) region.
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('Routing' under t47 Feature Updates has no ko counterpart under k48/k49; belongs to missing 2024.08.27 Added Features section (k55)) -->
 ##### Routing
 * Added API to get gateway information associated with routing tables to the Public API. See the [VPC API Guide](/Network/VPC/en/public-api/).
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('VPN Gateway' under t47 Feature Updates has no ko counterpart under k48/k49; belongs to missing 2024.08.27 Added Features section (k56)) -->
 ##### VPN Gateway
 * Added support for Diffie-Hellman groups 14,15,16,17,18,19,20,21,27,28.
 
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (Second 'Feature Updates' L4 under November 26, 2024 has no ko counterpart; belongs to missing 2024.08.27 Feature Updates section (k57)) -->
 #### Feature Updates
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('Load Balancer' under t53 has no ko counterpart under k48; belongs to missing 2024.08.27 k58) -->
 ##### Load Balancer
 * You can specify a port number per member.
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('Region Peering' under t53 has no ko counterpart under k48; belongs to missing 2024.08.27 k59) -->
 ##### Region Peering
 * Added the feature to attach to VPCs created in other projects.
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('Transit Hub' under t53 has no ko counterpart under k48; belongs to missing 2024.08.27 k60) -->
 ##### Transit Hub
 * Added the feature to share multicast domains to other projects. You can have multicast communication between VPCs created in different projects.
 
-### May 28, 2024
+<a id="may-28-2024"></a>
+### May 28, 2024 { #may-28-2024 }
 
+<a id="may-28-2024-added-features"></a>
 #### Added Features
 
+##### Load Balancer
+
+<!-- TODO: translate body -->
+
+##### VPN Gateway
+
+<!-- TODO: translate body -->
+
+##### Network ACL
+
+<!-- TODO: translate body -->
+
+##### Service Gateway
+
+<!-- TODO: translate body -->
+
+##### DNS Plus
+
+<!-- TODO: translate body -->
+
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('Load Balancer' L4 under May 28, 2024 has no ko L4 counterpart; ko k63 is L5 under k62) -->
 #### Load Balancer
 * Added the L7 load balancing feature. See [Load Balancer User Guide](/Network/Load%20Balancer/en/console-guide/).
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('VPN Gateway' L4 under May 28, 2024 has no ko L4 counterpart; ko k64 is L5 under k62) -->
 #### VPN Gateway
 * Added Cisco - Firepower 1000 Series to the peer gateway equipment.
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('Network ACL' L5 under t60 VPN Gateway has no ko counterpart at this nesting; ko k65 is L5 under k62) -->
 ##### Network ACL
 * Added the Network ACL feature to the Korea (Pangyo) region.
 * Integrated Network ACL with CloudTrail.
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('Service Gateway' L5 under t60 VPN Gateway has no ko counterpart at this nesting; ko k66 is L5 under k62) -->
 ##### Service Gateway
 * Added Service Gateway-related APIs to the Public APIs. See [Service Gateway API Guide](/Network/Service%20Gateway/en/public-api/).
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('DNS Plus' L5 under t60 VPN Gateway has no ko counterpart at this nesting; ko k67 is L5 under k62) -->
 ##### DNS Plus
 * Added the feature to set the header for health check requests, health check interval, maximum response latency (timeout), and maximum number of retries in GSLB health checks.
 
+<a id="may-28-2024-feature-updates"></a>
 #### Feature Updates
 
 ##### Service Gateway
 * Added the domain field for API endpoints on the basic information tab.
 
-### March 26, 2024
+<a id="march-26-2024"></a>
+### March 26, 2024 { #march-26-2024 }
 
+<a id="march-26-2024-added-features"></a>
 #### Added Features
 
 ##### Transit Hub
 * Added Transit Hub-related APIs to Public APIs. See [Transit Hub API Guide](/Network/Transit%20Hub/en/public-api/).
 
-### March 12, 2024
+<a id="march-12-2024"></a>
+### March 12, 2024 { #march-12-2024 }
 
+<a id="march-12-2024-feature-updates"></a>
 #### Feature Updates
 
 ##### DNS Plus
 * Stopped support for the SPF record set type. You can use the TXT record set type instead.
     * For more information, see [RFC 7208#section-14.1](https://datatracker.ietf.org/doc/html/rfc7208#section-14.1).
 
-### February 27, 2024
+<a id="february-27-2024"></a>
+### February 27, 2024 { #february-27-2024 }
 
+<a id="february-27-2024-added-features"></a>
 #### Added Features
 
 ##### Floating IP
@@ -221,6 +331,7 @@
 * Added the feature to protect load balancer from deletion.
 * Added L7 Load Balancing-related API to Public API. See [Load Balancer API Guide](https://docs.nhncloud.com/en/Network/Load%20Balancer/en/public-api/).
 
+<a id="february-27-2024-feature-updates"></a>
 #### Feature Updates
 
 ##### Private DNS
@@ -230,8 +341,10 @@
 ##### Transit Hub
 * Added BLACKHOLE, which destroys packets, to the routing rule packet processing method.
 
-### November 28, 2023
+<a id="november-28-2023"></a>
+### November 28, 2023 { #november-28-2023 }
 
+<a id="november-28-2023-added-features"></a>
 #### Added Features
 
 ##### Load Balancer
@@ -243,8 +356,10 @@
 * Added the Private DNS service. You can configure independent DNS for each VPC. 
   * Private DNS is only available in the Korea (Pyeongchon) region and Korea (Pangyo) region.
 
-### August 29, 2023
+<a id="august-29-2023"></a>
+### August 29, 2023 { #august-29-2023 }
 
+<a id="august-29-2023-added-features"></a>
 #### Added Features
 
 ##### Transit Hub
@@ -268,8 +383,10 @@
 
 * [Pyeongchon region, Korea]  Released Public API. See [Network ACL API Guide](https://docs.nhncloud.com/en/Network/Network%20ACL/en/public-api/).
 
-### May 30, 2023
+<a id="may-30-2023"></a>
+### May 30, 2023 { #may-30-2023 }
 
+<a id="may-30-2023-feature-updates"></a>
 #### Feature Updates
 
 ##### Network Interface
@@ -278,8 +395,10 @@
     * Added the search feature.
     * Improved to display device names.
 
-### March 28, 2023
+<a id="march-28-2023"></a>
+### March 28, 2023 { #march-28-2023 }
 
+<a id="march-28-2023-added-features"></a>
 #### Added Features
 
 ##### Traffic Mirroring
@@ -287,18 +406,31 @@
 * Added the Traffic Mirroring feature. Packets can be captured and routed to detection tools for purposes such as content security, threat analysis, and troubleshooting.
     * Traffic Mirroring is only available in Korea (Pyeongchon) and Korea (Pangyo) regions.
 
+<a id="march-28-2023-feature-updates"></a>
 #### Feature Updates
 
 ##### VPC
 
 * Added the VPC and VPC Subnet API to Public API. For more information, see [VPC API Guide](https://docs.nhncloud.com/en/Network/VPC/en/public-api/). 
 
+<a id="march-28-2023-1"></a>
+#### Feature Changes
+
+<!-- TODO: translate body -->
+
+##### VPC, Floating IP, Security Groups, Load Balancer
+
+<!-- TODO: translate body -->
+
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 ('VPC, Floating IP, Security Groups, Load Balancer' placed as L5 under t96 Feature Updates; ko k103 is L5 under k102 (Feature Changes), which is a missing heading in target) -->
 ##### VPC, Floating IP, Security Groups, Load Balancer
 
 * Changed API endpoint addresses.
 
-### January 31, 2023
+<a id="january-31-2023"></a>
+### January 31, 2023 { #january-31-2023 }
 
+<a id="january-31-2023-feature-updates"></a>
 #### Feature Updates
 
 ##### Colocation Gateway
@@ -310,16 +442,20 @@
 * Removed the constraint where communication is only possible for service gateway within the same VPC. 
 * You can use the service gateway of other VPCs via peering gateway and colocation gateway.
 
-### November, 29, 2022
+<a id="november-29-2022"></a>
+### November, 29, 2022 { #november-29-2022 }
 
+<a id="november-29-2022-added-features"></a>
 #### Added Features
 
 ##### Peering Gateway
 
 * [Pyeongchon/Pangyo region, Korea] Added the feature to configure a route for Peering, Project peering, and Region peering.
 
-### October 26, 2022
+<a id="october-26-2022"></a>
+### October 26, 2022 { #october-26-2022 }
 
+<a id="october-26-2022-feature-updates"></a>
 #### Feature Updates
 
 ##### Service Gateway
@@ -327,16 +463,20 @@
 * Added a supported service
     * NCR
 
-### July 26, 2022
+<a id="july-26-2022"></a>
+### July 26, 2022 { #july-26-2022 }
 
+<a id="july-26-2022-added-features"></a>
 #### Added Features
 
 ##### Load Balancer
 
 * Added the feature to change host header field values for health checks.
 
-### June 30, 2022
+<a id="june-30-2022"></a>
+### June 30, 2022 { #june-30-2022 }
 
+<a id="june-30-2022-feature-updates"></a>
 #### Feature Updates
 
 ##### Service Gateway
@@ -344,8 +484,10 @@
 * Added a supported service
     * CloudTrail
 
-### May 24, 2022
+<a id="may-24-2022"></a>
+### May 24, 2022 { #may-24-2022 }
 
+<a id="may-24-2022-added-features"></a>
 #### Added Features
 
 ##### Peering Gateway
@@ -362,8 +504,10 @@
 * [Pangyo region, Korea] Added the NAT Gateway feature.
 
 
-### March 29, 2022
+<a id="march-29-2022"></a>
+### March 29, 2022 { #march-29-2022 }
 
+<a id="march-29-2022-added-features"></a>
 #### Added Features
 
 ##### VPC
@@ -373,8 +517,10 @@
 * Added the inter-region peering feature, which allows you to connect two VPCs created in different regions.
     * Inter-region peering is only available in the Korea (Pyeongchon) region and the Korea (Pangyo) region.
 
-### January 18, 2022
+<a id="january-18-2022"></a>
+### January 18, 2022 { #january-18-2022 }
 
+<a id="january-18-2022-added-features"></a>
 #### Added Features
 
 ##### VPC
@@ -387,14 +533,17 @@
 * Added the feature to create virtual IP for redundancy. You can preempt an IP to use as a virtual IP, and add a route to the IP in the routing table.
 * Added the feature to disable network interface security settings so that the instance can be used as a gateway, firewall, etc.
 
+<a id="january-18-2022-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
 
 * Enhanced to use TLS version 1.3 with load balancers that use the TERMINATED_HTTPS protocol.
 
-### August 24, 2021
+<a id="august-24-2021"></a>
+### August 24, 2021 { #august-24-2021 }
 
+<a id="august-24-2021-added-features"></a>
 #### Added Features
 
 ##### DNS Plus
@@ -402,8 +551,10 @@
 * Added the Create multiple record sets feature.
 
 
-### April 27, 2021
+<a id="april-27-2021"></a>
+### April 27, 2021 { #april-27-2021 }
 
+<a id="april-27-2021-added-features"></a>
 #### Added Features
 
 ##### NAT instance
@@ -414,8 +565,10 @@
 
 * [Pyeongchon region, Korea] Physical load balancers can be created online. To learn more about the changes from the previous load balancers, see [Load Balancer Guide](https://docs.toast.com/en/Network/Load%20Balancer/en/console-guide/#difference-between-physical-load-balancers-and-regular-load-balancer).
 
-### March 23, 2021
+<a id="march-23-2021"></a>
+### March 23, 2021 { #march-23-2021 }
 
+<a id="march-23-2021-added-features"></a>
 #### Added Features
 
 ##### NAT Gateway
@@ -427,8 +580,10 @@
 * [Korea/Japan/United States] Added the Block Invalid Request feature.
 * [Korea/Japan/United States regions] The default connection limit of newly created load balancers is changed from 2,000 to 60,000.
 
-### February 6, 2021
+<a id="february-6-2021"></a>
+### February 6, 2021 { #february-6-2021 }
 
+<a id="february-6-2021-feature-updates"></a>
 #### Feature Updates
 
 ##### VPC
@@ -436,23 +591,29 @@
 * [Pangyo region, Korea] Fixed the issue where the default route (local route to the whole VPC address area) of routing table is not properly applied. Previously, even subnets within the VPC same could communicate with one another only if they are all connected to the same routing table. Now, communication is possible between subnets connected to different routing tables.
 
 
-### November 24, 2020
+<a id="november-24-2020"></a>
+### November 24, 2020 { #november-24-2020 }
 
+<a id="november-24-2020-feature-updates"></a>
 #### Feature Updates
 
-#### Network Interface
+##### Network Interface
 * Added Network Interface service.
 
-### September 22, 2020
+<a id="september-22-2020"></a>
+### September 22, 2020 { #september-22-2020 }
 
+<a id="september-22-2020-feature-updates"></a>
 #### Feature Updates
 
 ##### DNS Plus
 
 * Improved the application to enable the editing of the record set type when editing a record set.
 
-### August 25, 2020
+<a id="august-25-2020"></a>
+### August 25, 2020 { #august-25-2020 }
 
+<a id="august-25-2020-added-features"></a>
 #### Added Features
 
 ##### Network ACL
@@ -463,15 +624,19 @@
 
 * Public API v2 supports IP access control function. For details, refer to [Load Balancer API Guide](https://docs.toast.com/en/Network/Load%20Balancer/en/public-api/#ip-acl).
 
-### June 23, 2020
+<a id="june-23-2020"></a>
+### June 23, 2020 { #june-23-2020 }
 
+<a id="june-23-2020-features-updates"></a>
 #### Features Updates
 
 ##### VPC
 * [Korea/Japan/United States] Changed the way to enter the IP of a gateway from manually typing in the address to selecting the device owning the IP from the Create Route window of a routing table. The devices that are not explicitly associated with a routing table in the subnet can also be selected.
 * [Korea/Japan/United States] Changed the Internet gateway list to display the information of the associated routing table instead of the IP information. The name of the associated Internet gateway is also displayed in the Route tab of a routing table.
 
-### May 26, 2020
+<a id="may-26-2020"></a>
+### May 26, 2020 { #may-26-2020 }
+<a id="may-26-2020-feature-updates"></a>
 #### Feature Updates
 
 ##### VPC
@@ -485,8 +650,10 @@
 * Now, the member instance of each listener can be configured differently. Previously, all the listeners needed to have the same member instance when running multiple listeners in Load Balancer.
 * Released Public API v2, which is compatible with OpenStack API.
 
-### March 24, 2020
+<a id="march-24-2020"></a>
+### March 24, 2020 { #march-24-2020 }
 
+<a id="march-24-2020-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
@@ -494,16 +661,20 @@
 * Added Certificate management through the Cert Manager service.
 * By registering a certificate at Cert Manager and connecting it to the listener, you can receive an email on certificate expiration date.
 
-### February 25, 2020
+<a id="february-25-2020"></a>
+### February 25, 2020 { #february-25-2020 }
 
+<a id="february-25-2020-feature-updates"></a>
 #### Feature Updates
 
 ##### Security Group
 
 * Added "Description" entry to security group rules. You can add description for each security group rule.
 
-### December 24, 2019
+<a id="december-24-2019"></a>
+### December 24, 2019 { #december-24-2019 }
 
+<a id="december-24-2019-added-features"></a>
 #### Added Features
 
 ##### DNS Plus
@@ -513,27 +684,34 @@
 * The pool serves as a grouping element for endpoint servers at the minimum unit so as to apply the routing rule.
 * Health check is conducted on a regular basis for endpoint servers included to a pool so as to support stable services. Health check is supported for HTTP/HTTPS/TCP.
 
+<a id="december-24-2019-feature-updates"></a>
 #### Feature Updates
 
 ##### DNS Plus
 
 * Updated to select user's GSLB domain for CNAME record set type, for creating/updating the record set.
 
-### December 17. 2019
+<a id="december-17-2019"></a>
+### December 17. 2019 { #december-17-2019 }
 
+<a id="december-17-2019-feature-updates"></a>
 #### Feature Updates
 * [Korea/Japan/US Region] Every network interface connected with an instance can be assosicated with each floating IP.
 
-### October 29, 2019
+<a id="october-29-2019"></a>
+### October 29, 2019 { #october-29-2019 }
 
+<a id="october-29-2019-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
 
 * Added the feature of notification via web console, for chain certificate registration, when an individual certificate which is included in the certificate file has an invalid format.
 
-### August 27, 2019
+<a id="august-27-2019"></a>
+### August 27, 2019 { #august-27-2019 }
 
+<a id="august-27-2019-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
@@ -546,8 +724,10 @@
 * Exceeded the maximum available number of record sets to be created. For each DNS zone, up to 5,000 record sets can be created.
 * Modified, in the query of record set statistics for CNAME, to query A record set type along with AAAA record set type.
 
-### June 25, 2019
+<a id="june-25-2019"></a>
+### June 25, 2019 { #june-25-2019 }
 
+<a id="june-25-2019-release-of-new-products"></a>
 #### Release of New Products
 
 ##### DNS Plus
@@ -555,8 +735,10 @@
 * DNS Plus provides features for domain management.
 * It is easy to configure a DNS server.
 
-### May 30, 2019
+<a id="may-30-2019"></a>
+### May 30, 2019 { #may-30-2019 }
 
+<a id="may-30-2019-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
@@ -565,16 +747,20 @@
     * IP-based access control is available for load balancer.
     * For more details on IP access control, see user guides.
 
-### May 28, 2019
+<a id="may-28-2019"></a>
+### May 28, 2019 { #may-28-2019 }
 
+<a id="may-28-2019-feature-updates"></a>
 #### Feature Updates
 
 ##### VPC
 
 * [Korea Region] Creating a peering can be made available again.
 
-### April 25, 2019
+<a id="april-25-2019"></a>
+### April 25, 2019 { #april-25-2019 }
 
+<a id="april-25-2019-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
@@ -584,8 +770,10 @@
     * For more details on IP access control features, see User Guide.
     * List of IPs for control has been auto-applied to the IP access control group named Default.
 
-### December 27, 2018
+<a id="december-27-2018"></a>
+### December 27, 2018 { #december-27-2018 }
 
+<a id="december-27-2018-feature-updates"></a>
 #### Feature Updates
 
 ##### VPC
@@ -593,14 +781,17 @@
 * Creating a new peering is not going to be provided for the time being, due to concerns for packet flooding between peered VPCs.
 	Such concerns, however, are not related to communication between previously created peering, and features are provided as usual, except peering creation.
 
-### November 27, 2018
+<a id="november-27-2018"></a>
+### November 27, 2018 { #november-27-2018 }
 
+<a id="november-27-2018-bug-fixes"></a>
 #### Bug Fixes
 
 ##### Load Balancer
 
 * Fixed a bug occurring when a listener is added to load balancer, in which, an instance member that is newly added to a deactivate instance is created while activated.
 
+<a id="november-27-2018-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
@@ -612,14 +803,17 @@
     * For more details, see User Guide.
 
 
-### September 20, 2018
+<a id="september-20-2018"></a>
+### September 20, 2018 { #september-20-2018 }
 
+<a id="september-20-2018-bug-fixes"></a>
 #### Bug Fixes
 
 ##### Load Balancer
 
 * Fixed an issue in which some listener members still remain after an instance which is registered as member of load balancer is deleted.
 
+<a id="september-20-2018-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
@@ -627,14 +821,17 @@
 * Added dedicated load balancer services.
 * Since dedicated load balancer services are created by occupying hardware resources, 1Gbps bandwidth for 48 thousand concurrent sessions are supported.
 
-### August 28, 2018
+<a id="august-28-2018"></a>
+### August 28, 2018 { #august-28-2018 }
 
+<a id="august-28-2018-bug-fixes"></a>
 #### Bug Fixes
 
 ##### VPC
 
 * Fixed an issue in which deleting may be tried to VPC with subnets that have routes
 
+<a id="august-28-2018-feature-updates"></a>
 #### Feature Updates
 
 ##### VPC
@@ -651,14 +848,17 @@
 * Keepalive timeout can be configured for load balancer.
 
 
-### April 24, 2018
+<a id="april-24-2018"></a>
+### April 24, 2018 { #april-24-2018 }
 
+<a id="april-24-2018-bug-fixes"></a>
 #### Bug Fixes
 
 ##### VPC
 
 * Fixed failed access to load balancer of a peer VPC from instance of a local VPC.
 
+<a id="april-24-2018-feature-updates"></a>
 #### Feature Updates
 
 ##### VPC
@@ -678,8 +878,10 @@
 * Changed the Keeaplive Timeout to 5 minutes.
 * Up to 60,000 session limit can be configured for listener.
 
-### March 22, 2018
+<a id="march-22-2018"></a>
+### March 22, 2018 { #march-22-2018 }
 
+<a id="march-22-2018-bug-fixes"></a>
 #### Bug Fixes
 
 ##### VPC
@@ -688,14 +890,17 @@
 * Fixed an issue in which the same target of a previous routing policy may be entered to add a routing policy.
 * Fixed infrequently failed communication of an instance associated to a floating IP with an instance located at a different subnet.
 
-### February 22, 2018
+<a id="february-22-2018"></a>
+### February 22, 2018 { #february-22-2018 }
 
+<a id="february-22-2018-bug-fixes"></a>
 #### Bug Fixes
 
 ##### VPC
 
 * Fixed failed traffic from an instance associated with floating IP to a local network.
 
+<a id="february-22-2018-feature-updates"></a>
 #### Feature Updates
 
 ##### Adopted VPC as Basic Model for Network
@@ -708,22 +913,28 @@
 * For more details, Overview and User Guide of VPC.
 
 
-### November 23, 2017
+<a id="november-23-2017"></a>
+### November 23, 2017 { #november-23-2017 }
 
+<a id="november-23-2017-bug-fixes"></a>
 #### Bug Fixes
 
 ##### Load Balancer
 * Fixed the display of invalid connection limit for listener, when a load balancer is created.
 
-### October 26, 2017
+<a id="october-26-2017"></a>
+### October 26, 2017 { #october-26-2017 }
 
+<a id="october-26-2017-bug-fixes"></a>
 #### Bug Fixes
 
 ##### Load Balancer
 * Fixed failure in certificate registration when a load balancer is created.
 
-### September 21, 2017
+<a id="september-21-2017"></a>
+### September 21, 2017 { #september-21-2017 }
 
+<a id="september-21-2017-added-features"></a>
 #### Added Features
 
 ##### Added Public API
@@ -731,34 +942,43 @@
 * Like Object Storage, you can also manage Compute & Network by using APIs.
 * The feature is limited at the moment, but will be extended by adding more APIs.
 
+<a id="september-21-2017-bug-fixes"></a>
 #### Bug Fixes
 
 * Fixed to disallow users without project admin authority to modify security group.
 * Updated not to show the Network menu to users, except authorized admin users of a project.
 
-### August 24, 2017
+<a id="august-24-2017"></a>
+### August 24, 2017 { #august-24-2017 }
 
+<a id="august-24-2017-bug-fixes"></a>
 #### Bug Fixes
 
 ##### Load Balancer
 * Fixed a bug in which the session persistence of load balancer did not show properly.
 
-### April 20, 2017
+<a id="april-20-2017"></a>
+### April 20, 2017 { #april-20-2017 }
 
+<a id="april-20-2017-bug-fixes"></a>
 #### Bug Fixes
 ##### Load Balancer
 * Fixed a bug in which the popup for certificate registration is frequently missing while uploading certificate files to listener.
 
 
-### March 23, 2017
+<a id="march-23-2017"></a>
+### March 23, 2017 { #march-23-2017 }
 
+<a id="march-23-2017-bug-fixes"></a>
 #### Bug Fixes
 ##### Floating IP
 * Fixed failed display of the "Create" button on the popup for associating with floating IP.
 
 
-### February 23, 2017
+<a id="february-23-2017"></a>
+### February 23, 2017 { #february-23-2017 }
 
+<a id="february-23-2017-feature-updates"></a>
 #### Feature Updates
 
 ##### Load Balancer
@@ -776,16 +996,20 @@
 	  * Name for the target of floating IP to be associated with is changed from "Port" to "Network Interface".
 
 
-### January 19, 2017
+<a id="january-19-2017"></a>
+### January 19, 2017 { #january-19-2017 }
 
+<a id="january-19-2017-bug-fixes"></a>
 #### Bug Fixes
 ##### Load Balancer
 * Fixed the issue in which the restricted connection setting was not applied when creating a load balancer.
 
 
 
-### December 22, 2016
+<a id="december-22-2016"></a>
+### December 22, 2016 { #december-22-2016 }
 
+<a id="december-22-2016-bug-fixes"></a>
 #### Bug Fixes
 
 ##### Load Balancer
@@ -802,8 +1026,10 @@
 
 
 
-### December 8, 2016
+<a id="december-8-2016"></a>
+### December 8, 2016 { #december-8-2016 }
 
+<a id="december-8-2016-bug-fixes"></a>
 #### Bug Fixes
 
 ##### Load Balancer
@@ -817,30 +1043,38 @@
 
 
 
-### November 29, 2016
+<a id="november-29-2016"></a>
+### November 29, 2016 { #november-29-2016 }
 
+<a id="november-29-2016-bug-fixes"></a>
 #### Bug Fixes
 ##### Load Balancer
 * Fixed failure in creating TERMINATED_HTTPS-type load balancers.
 
 
 
-### November 24, 2016
+<a id="november-24-2016"></a>
+### November 24, 2016 { #november-24-2016 }
 
+<a id="november-24-2016-feature-updates"></a>
 #### Feature Updates
 ##### Load Balancer
 * Updated to show the value of session limit per listener of load balancer.
 
+<a id="november-24-2016-bug-fixes"></a>
 #### Bug Fixes
 ##### Load Balancer
 * Fixed failure in creating load balancers at a particular project.
 
-### August 4, 2016
+<a id="august-4-2016"></a>
+### August 4, 2016 { #august-4-2016 }
 
+<a id="august-4-2016-feature-updates"></a>
 #### Feature Updates
 ##### Load Balancer
 * Added SSL offloading of load balancer.
 
+<a id="august-4-2016-bug-fixes"></a>
 #### Bug Fixes
 ##### Load Balancer
 * Fixed infrequent failure in closing when load balancer is removed.

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,7 +1,10 @@
-## Network > リリースノート
+<a id="network-release-notes"></a>
+## Network > リリースノート { #network-release-notes }
 
-### 2026. 05. 27.
+<a id="may-27-2026"></a>
+### 2026. 05. 27. { #may-27-2026 }
 
+<a id="may-27-2026-added-features"></a>
 #### 機能追加
 
 ##### Network Interface
@@ -14,6 +17,7 @@
 * Load Balancer(DSR)は、韓国(ピョンチョン)リージョンと韓国(パンギョ)リージョンでのみ利用できます。
 * [Load Balancer(DSR) コンソール使用ガイド](/Network/Load%20Balancer(DSR)/ja/console-guide/)を参照してください。
 
+<a id="may-27-2026-feature-updates"></a>
 #### 機能改善
 
 ##### Load Balancer
@@ -26,43 +30,60 @@
     * パケットが通過したネットワーク経路(VPC Local、Internet Gateway、VPN Gateway、VPC Peering、Region Peering、Project Peering、Service Gateway)を整数値で確認できます。
     * [Flow Log 概要](/Network/Flow%20Log/ja/overview/)を参照してください。
 
+<a id="may-27-2026-may-27-2026-feature-updates"></a>
 #### 機能変更
 
 ##### VPC
 * ネットワークサービスの連携をサポートするため、VPCの内部トラフィック処理方式が一部変更されました。新しく作成されるVPCから適用されます。
 
-### 2026. 04. 14.
+<a id="april-14-2026"></a>
+### 2026. 04. 14. { #april-14-2026 }
 
+<a id="april-14-2026-added-features"></a>
 #### 機能追加
 
 ##### DNS Plus
 * API v2.0の追加
     * User Access Keyトークンをサポートします。
 
-### 2025. 11. 25.
+<a id="november-25-2025"></a>
+### 2025. 11. 25. { #november-25-2025 }
 
+<a id="november-25-2025-added-features"></a>
 #### 機能追加
 
 ##### VPN Gateway
 * VPNが接続されたVPCにTransit Hubを接続すると、Transit Hubに接続された他のプロジェクトのVPCからもオンプレミスネットワークとのVPN通信をサポートします。(接続された帯域へのVPN Connectionの追加作成が必要です)
 
-###### Service Gateway
+##### Service Gateway
 * Service Gatewayを作成する際に、ユーザーがNAT IPを固定して作成できるよう改善しました。
 
-###### Traffic Mirroring
+##### Traffic Mirroring
 * Public APIにTraffic Mirroring関連のAPIが追加されました。[Traffic Mirroring API ガイド](/Network/Traffic%20Mirroring/ja/public-api/)をご参照ください。
 
 ##### Load Balancer
 * リスナーごとのユーザー定義レスポンス設定機能が追加されました。
 * X-Forwarded-* ヘッダの有効化・無効化機能が追加されました。
 
+<a id="november-25-2025-feature-updates"></a>
 #### 機能改善
 
 ##### Load Balancer 
 * 複数のSSL証明書の登録・管理機能がコンソールでサポートされます。
 
-### 2025. 08. 26.
+<a id="november-25-2025-1"></a>
+#### 機能変更
 
+<!-- TODO: translate body -->
+
+##### DNS Plus
+
+<!-- TODO: translate body -->
+
+<a id="august-26-2025"></a>
+### 2025. 08. 26. { #august-26-2025 }
+
+<a id="august-26-2025-added-features"></a>
 #### 機能追加
 
 ##### VPN Gateway
@@ -77,8 +98,10 @@
 ##### Load Balancer
 ロードバランサーのCPU使用率、リスナー単位の統計、ソケットの接続状態といった指標をCloud Monitoringサービスで確認できる機能を追加しました。
 
-### 2025. 05. 27.
+<a id="may-27-2025"></a>
+### 2025. 05. 27. { #may-27-2025 }
 
+<a id="may-27-2025-added-features"></a>
 #### 機能追加
 
 ##### NAT Gateway
@@ -103,18 +126,49 @@
 ##### Flow Log
 * Region peering gateway, Project peering gateway, Colocation gatewayのネットワークインターフェースを対象にFlow Logを作成できるように機能を追加しました。
 
+<a id="may-27-2025-feature-updates"></a>
 #### 機能改善
 ##### Flow Log
 * Flow LogのファイルをOBSに保存する際、フォルダとファイル名を自由に編集できるように改善しました。
 
   
-### 2025. 04. 29.
+<a id="april-29-2025"></a>
+### 2025. 04. 29. { #april-29-2025 }
 
+<a id="april-29-2025-feature-updates"></a>
 #### 機能変更
 ##### DNS Plus
 * レコードセットTTLの最小値を1から10に変更しました。
 
-### 2024. 11. 26.
+<a id="march-4-2025"></a>
+### 2025. 03. 04. { #march-4-2025 }
+
+<!-- TODO: translate body -->
+
+<a id="march-4-2025-feature-updates"></a>
+#### 機能改善
+
+<!-- TODO: translate body -->
+
+##### Service Gateway
+
+<!-- TODO: translate body -->
+
+##### Load Balancer
+
+<!-- TODO: translate body -->
+
+##### Flow Log
+
+<!-- TODO: translate body -->
+
+##### Routing
+
+<!-- TODO: translate body -->
+
+<a id="november-26-2024"></a>
+### 2024. 11. 26. { #november-26-2024 }
+<a id="november-26-2024-feature-updates"></a>
 #### 機能改善
 ##### Peering Gateway
 * ピアリングに説明項目が追加されました。ピアリングの作成または変更時に、そのピアリングの説明を入力することができ、ピアリングの基本情報に表示されます。
@@ -123,8 +177,10 @@
 * gzip圧縮機能が追加されました。
 * Flow Logがサポートする統計提供情報項目の中から、ユーザーが希望する項目だけを選択して記録を残せるように改善されました。サポートする統計項目は[Flowlog概要](/Network/Flow%20Log/ja/overview/)を参照してください。
 
-### 2024. 08. 27.
+<a id="network-release-notes-1"></a>
+### 2024. 08. 27. { #network-release-notes-1 }
 
+<a id="network-release-notes-1-1"></a>
 #### 機能追加
 
 ##### Flow Log
@@ -138,6 +194,7 @@
 * Diffie-Hellman groups 14,15,16,17,18,19,20,21,27,28をサポートします。
 
 
+<a id="network-release-notes-1-2"></a>
 #### 機能改善
 
 ##### Load Balancer
@@ -149,14 +206,16 @@
 ##### Transit Hub
 * マルチキャストドメインを他のプロジェクトに共有できるように機能が追加されました。他のプロジェクトで作成されたVPC間でマルチキャスト通信を行うことができます。
 
-### 2024. 05. 28.
+<a id="may-28-2024"></a>
+### 2024. 05. 28. { #may-28-2024 }
 
+<a id="may-28-2024-added-features"></a>
 #### 機能追加
 
-#### Load Balancer
+##### Load Balancer
 * L7ロードバランシング機能が追加されました。 [ロードバランサーユーザーガイド](/Network/Load%20Balancer/ja/console-guide/)を参照してください。
 
-#### VPN Gateway
+##### VPN Gateway
 * ピアゲートウェイ機器にCisco - Firepower 1000 Seriesが追加されました。
 
 ##### Network ACL
@@ -170,30 +229,38 @@
 * GSLBヘルスチェックでヘルスチェックリクエストのヘッダ、ヘルスチェック周期、最大レスポンス待機時間、最大再試行回数設定機能が追加されました。
 
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (Duplicate '2024. 03. 26.' date heading; ko has only one k70 for this date, and this section's 機能改善/Service Gateway content belongs under k61 (2024.05.28 機能改善) misplaced here) -->
 ### 2024. 03. 26.
 
+<a id="may-28-2024-feature-updates"></a>
 #### 機能改善
 
 ##### Service Gateway
 * 基本情報タブにAPIエンドポイントドメイン項目が追加されました。
 
-### 2024. 03. 26.
+<a id="march-26-2024"></a>
+### 2024. 03. 26. { #march-26-2024 }
 
+<a id="march-26-2024-added-features"></a>
 #### 機能追加
 
 ##### Transit Hub
 * Public APIにTransit Hub関連APIが追加されました。[Transit Hub APIガイド](/Network/Transit%20Hub/ja/public-api/)を参照してください。
 
-### 2024. 03. 12.
+<a id="march-12-2024"></a>
+### 2024. 03. 12. { #march-12-2024 }
 
+<a id="march-12-2024-feature-updates"></a>
 #### 機能改善
 
 ##### DNS Plus
 * SPF レコードセットタイプのサポートは終了しました。代わりにTXTレコードセットタイプを使用できます。
     * 詳細は[[RFC 7208#section-14.1]](https://datatracker.ietf.org/doc/html/rfc7208#section-14.1)で確認できます。
 
-### 2024. 02. 27.
+<a id="february-27-2024"></a>
+### 2024. 02. 27. { #february-27-2024 }
 
+<a id="february-27-2024-added-features"></a>
 #### 機能追加
 
 ##### Floating IP
@@ -203,6 +270,7 @@
 * ロードバランサー削除保護機能が追加されました。
 * Public APIにL7ロードバランシング関連APIが追加されました。 [ロードバランサーAPIガイド](https://docs.nhncloud.com/ja/Network/Load%20Balancer/ja/public-api/)を参照してください。
 
+<a id="february-27-2024-feature-updates"></a>
 #### 機能改善/変更
 
 ##### Private DNS
@@ -212,8 +280,10 @@
 ##### Transit Hub
 * ルーティングルールのパケット処理方法にパケットを消滅させるBLACKHOLEが追加されました。
 
-### 2023. 11. 28.
+<a id="november-28-2023"></a>
+### 2023. 11. 28. { #november-28-2023 }
 
+<a id="november-28-2023-added-features"></a>
 #### 機能追加
 
 ##### Load Balancer
@@ -225,8 +295,10 @@
 * Private DNS 新規サービスが追加されました。VPCごとに独立したDNSを構成できます。
   * Private DNSは韓国(平村)リージョンと韓国(板橋)リージョンでのみ利用可能です。
 
-### 2023. 08. 29.
+<a id="august-29-2023"></a>
+### 2023. 08. 29. { #august-29-2023 }
 
+<a id="august-29-2023-added-features"></a>
 #### 機能追加
 
 ##### Transit Hub
@@ -250,8 +322,10 @@
 
 * 韓国(ピョンチョン) Public APIがリリースされました。[Network ACL APIガイド](https://docs.nhncloud.com/ja/Network/Network%20ACL/ja/public-api/)を参照してください。
 
-### 2023. 05. 30.
+<a id="may-30-2023"></a>
+### 2023. 05. 30. { #may-30-2023 }
 
+<a id="may-30-2023-feature-updates"></a>
 #### 機能改善
 
 ##### Network Interface
@@ -260,8 +334,10 @@
     * 検索機能が追加されました。
     * 装置名を表示するように改善しました。
 
-### 2023. 03. 28.
+<a id="march-28-2023"></a>
+### 2023. 03. 28. { #march-28-2023 }
 
+<a id="march-28-2023-added-features"></a>
 #### 機能追加
 
 ##### Traffic Mirroring
@@ -269,20 +345,24 @@
 * Traffic Mirroring機能が追加されました。パケットをキャプチャしてコンテンツセキュリティ、脅威分析、トラブルシューティングなどの目的を持つ検出ツールにルーティングできます。
     * トラフィックミラーリングは韓国(ピョンチョン)リージョンと韓国(パンギョ)リージョンでのみ利用できます。
 
+<a id="march-28-2023-feature-updates"></a>
 #### 機能改善 
 
 ##### VPC
 
 * Public APIにVPCおよびVPC Subnet APIが追加されました。詳細については、 [VPC APIユーザーガイド](https://docs.nhncloud.com/ja/Network/VPC/ja/public-api/)を参照してください。 
 
+<a id="march-28-2023-1"></a>
 #### 機能変更
 
 ##### VPC、Floating IP、Security Groups、Load Balancer
 
 * APIエンドポイントアドレスが変更されました。
 
-### 2023. 01. 31.
+<a id="january-31-2023"></a>
+### 2023. 01. 31. { #january-31-2023 }
 
+<a id="january-31-2023-feature-updates"></a>
 #### 機能改善
 
 ##### Colocation Gateway
@@ -294,16 +374,20 @@
 * 同じVPC内のサービスゲートウェイのみ通信が可能な制約事項が削除されました。 
 * ピアリングゲートウェイ、コロケーションゲートウェイを経由して他のVPCのサービスゲートウェイを利用できます。
 
-### 2022. 11. 29.
+<a id="november-29-2022"></a>
+### 2022. 11. 29. { #november-29-2022 }
 
+<a id="november-29-2022-added-features"></a>
 #### 機能追加
 
 ##### Peering Gateway
 
 * [韓国ピョンチョン/パンギョリージョン]ピアリング、プロジェクトピアリング、リージョンピアリングにルートを設定できる機能が追加されました。
 
-### 2022. 10. 04.
+<a id="october-26-2022"></a>
+### 2022. 10. 04. { #october-26-2022 }
 
+<a id="october-26-2022-feature-updates"></a>
 #### 機能改善
 
 ##### Service Gateway
@@ -311,16 +395,20 @@
 * サポートサービス追加
     * NCR
 
-### 2022. 07. 26.
+<a id="july-26-2022"></a>
+### 2022. 07. 26. { #july-26-2022 }
 
+<a id="july-26-2022-added-features"></a>
 #### 機能追加
 
 ##### Load Balancer
 
 * ヘルスチェックのときにホストヘッダのフィールド値を変更することができる機能が追加されました。
 
-### 2022. 06. 30.
+<a id="june-30-2022"></a>
+### 2022. 06. 30. { #june-30-2022 }
 
+<a id="june-30-2022-feature-updates"></a>
 #### 機能改善
 
 ##### Service Gateway
@@ -328,8 +416,10 @@
 * サポートサービス追加
     * CloudTrail
 
-### 2022. 05. 24.
+<a id="may-24-2022"></a>
+### 2022. 05. 24. { #may-24-2022 }
 
+<a id="may-24-2022-added-features"></a>
 #### 機能追加
 
 ##### Peering Gateway
@@ -346,8 +436,10 @@
 * [韓国パンギョリージョン] NATゲートウェイ機能が追加されました。
 
 
-### 2022. 03. 29.
+<a id="march-29-2022"></a>
+### 2022. 03. 29. { #march-29-2022 }
 
+<a id="march-29-2022-added-features"></a>
 #### 機能追加
 
 ##### VPC
@@ -357,8 +449,10 @@
 * リージョン間ピアリング機能が追加されました。他のリージョンに作成された2つのVPCを接続できます。
     * リージョン間ピアリングは、韓国(坪村)リージョンと韓国(パンギョ)リージョンでのみ利用できます。
 
-### 2022. 01. 18.
+<a id="january-18-2022"></a>
+### 2022. 01. 18. { #january-18-2022 }
 
+<a id="january-18-2022-added-features"></a>
 #### 機能追加
 
 ##### VPC
@@ -371,22 +465,27 @@
 * 冗長化のための仮想IP作成機能が追加されました。仮想IPとして使用するIPを確保し、ルーティングテーブルからそのIPへのルートを追加できます。
 * インスタンスをゲートウェイ/ファイアウォールなどの用途で使用できるように、ネットワークインターフェイスのセキュリティ設定を解除する機能が追加されました。
 
+<a id="january-18-2022-feature-updates"></a>
 #### 機能改善
 
 ##### Load Balancer
 
 * TERMINATED_HTTPSプロトコルを使用するロードバランサーでTLS 1.3バージョンを使用できるように改善されました。
 
-### 2021. 08. 24.
+<a id="august-24-2021"></a>
+### 2021. 08. 24. { #august-24-2021 }
 
+<a id="august-24-2021-added-features"></a>
 #### 機能追加
 
 ##### DNS Plus
 
 * レコードセット大量作成機能が追加されました。
 
-### 2021. 04. 27.
+<a id="april-27-2021"></a>
+### 2021. 04. 27. { #april-27-2021 }
 
+<a id="april-27-2021-added-features"></a>
 #### 機能追加
 
 ##### NATインスタンス
@@ -397,8 +496,10 @@
 
 * [韓国坪村リージョン]物理ロードバランサーをオンラインで作成できます。既存のロードバランサーからの変更事項は[ロードバランサーガイド](https://docs.toast.com/ja/Network/Load%20Balancer/ja/console-guide/#_17)を参照してください。
 
-### 2021. 03. 23.
+<a id="march-23-2021"></a>
+### 2021. 03. 23. { #march-23-2021 }
 
+<a id="march-23-2021-added-features"></a>
 #### 機能追加
 
 ##### NATゲートウェイ
@@ -410,8 +511,10 @@
 * [韓国/日本/米国リージョン]有効ではないリクエストの遮断機能が追加されました。
 * [韓国/日本/米国リージョン]新たに作成されるロードバランサーの基本接続制限数が2,000から60,000に変更されます。
 
-### 2021. 02. 06.
+<a id="february-6-2021"></a>
+### 2021. 02. 06. { #february-6-2021 }
 
+<a id="february-6-2021-feature-updates"></a>
 #### 機能変更
 
 ##### VPC
@@ -419,23 +522,30 @@
 * [韓国パンギョリージョン]ルーティングテーブルの基本ルート(VPCアドレス領域全体へのローカルルート)が適用されない問題を修正しました。従来はVPC内のサブネットでも、同じルーティングテーブルに接続されているサブネット間でのみ通信が可能でしたが、異なるルーティングテーブルに接続されているサブネット間でも通信が可能です。
 
 
-### 2020. 11. 24.
+<a id="november-24-2020"></a>
+### 2020. 11. 24. { #november-24-2020 }
 
+<a id="november-24-2020-feature-updates"></a>
 #### 機能追加
 
-#### Network Interface
+##### Network Interface
 * Network Interface機能を追加しました。
 
-### 2020. 09. 22.
+<a id="september-22-2020"></a>
+### 2020. 09. 22. { #september-22-2020 }
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (Heading reads '機能変更' but ko k152 is '기능 개선' (機能改善); title mismatch means this cannot be confirmed as a translation — flagged as structurally anomalous extra) -->
+<a id="september-22-2020-feature-updates"></a>
 #### 機能変更
 
 ##### DNS Plus
 
 * レコードセットを修正時にレコードセットタイプを修正できるようになりました。
 
-### 2020. 08. 25.
+<a id="august-25-2020"></a>
+### 2020. 08. 25. { #august-25-2020 }
 
+<a id="august-25-2020-added-features"></a>
 #### 機能追加
 
 ##### Network ACL (韓国坪村リージョン)
@@ -443,16 +553,24 @@
 * Network ACL機能を追加しました。
 * ACL機能を利用してプロトコル、IP、ポートごとにアクセスを制御できます。
 
-### 2020. 06. 23.
+##### Load Balancer
 
+<!-- TODO: translate body -->
+
+<a id="june-23-2020"></a>
+### 2020. 06. 23. { #june-23-2020 }
+
+<a id="june-23-2020-features-updates"></a>
 #### 機能変更
 
 ##### VPC
 * [韓国/日本/米国リージョン]ルーティングテーブルのルート作成ウィンドウで、ゲートウェイ項目にIPを直接入力する方式から、IPを所有する機器を選択する方式に変更しました。ルーティングテーブルに明示的に接続していないサブネットの機器も選択できます。
 * [韓国/日本/米国リージョン]インターネットゲートウェイリストで、IP情報の代わりに接続したルーティングテーブルの情報を表示するように変更しました。ルーティングテーブルのルートタブでも接続したインターネットゲートウェイの名前が表示されます。
 
-### 2020. 05. 26.
+<a id="may-26-2020"></a>
+### 2020. 05. 26. { #may-26-2020 }
 
+<a id="may-26-2020-feature-updates"></a>
 #### 機能改善
 
 ##### VPC
@@ -465,8 +583,10 @@
 * ロードバランサーが属しているVPCがピアリング(peering)接続されている場合、ピアVPCに属しているインスタンスをロードバランサーのメンバーに登録できます。ピアVPCの基本ルーティングテーブルに接続されたサブネットのインスタンスのみ接続できます。
 * ロードバランサーに複数のリスナーを運用する場合、すべてのリスナーに同じメンバーインスタンスを構成する必要がありましたが、これからはリスナーごとにメンバーインスタンスを別々に設定できます。
 
-### 2020. 03. 24.
+<a id="march-24-2020"></a>
+### 2020. 03. 24. { #march-24-2020 }
 
+<a id="march-24-2020-feature-updates"></a>
 #### 機能改善
 
 ##### Load Balancer
@@ -474,16 +594,20 @@
 * Cert Managerサービスによる認証書の管理機能が追加されました。
 * Cert Managerサービスに証明書を登録し、リスナーに証明書を接続すると、証明書の有効期限のアラームをメールで受信できます。
 
-### 2020. 02. 25.
+<a id="february-25-2020"></a>
+### 2020. 02. 25. { #february-25-2020 }
 
+<a id="february-25-2020-feature-updates"></a>
 #### 機能改善
 
 ##### セキュリティグループ(security group)
 
 * セキュリティグループルールに「説明」項目を追加しました。セキュリティグループルールごとに説明を追加できます。
 
-### 2019. 12. 24.
+<a id="december-24-2019"></a>
+### 2019. 12. 24. { #december-24-2019 }
 
+<a id="december-24-2019-added-features"></a>
 #### 機能追加
 
 ##### DNS Plus
@@ -493,20 +617,25 @@
 * Poolはルーティングルールを適用することができる最小単位で、エンドポイントサーバーをグルーピングする要素です。
 * Poolに含まれたエンドポイントサーバーで周期的にヘルスチェックを行い、安定的なサービスをサポートします。ヘルスチェックはHTTP/HTTPS/TCPをサポートします。
 
+<a id="december-24-2019-feature-updates"></a>
 #### 機能改善
 
 ##### DNS Plus
 
 * レコードセットの作成/修正時、ユーザーのGSLBドメインを選択してCNAMEレコードセットタイプを入力できるように改善しました。
 
-### 2019. 12. 17.
+<a id="december-17-2019"></a>
+### 2019. 12. 17. { #december-17-2019 }
 
+<a id="december-17-2019-feature-updates"></a>
 #### 機能改善
 
 * [韓国/日本/米国リージョン] インスタンスに繋がった全てネットワークインターフェースにそれぞれフローティングIPを繋げます。
 
-### 2019. 10. 29.
+<a id="october-29-2019"></a>
+### 2019. 10. 29. { #october-29-2019 }
 
+<a id="october-29-2019-feature-updates"></a>
 #### 機能改善
 
 ##### Load Balancer
@@ -514,8 +643,10 @@
 * [韓国/日本リージョン] チェーン証明書を登録する時、証明書ファイルに含まれた各証明書の形式が無効な場合、 Webコンソールを通して通知する機能を追加しました。
 
 
-### 2019. 08. 27.
+<a id="august-27-2019"></a>
+### 2019. 08. 27. { #august-27-2019 }
 
+<a id="august-27-2019-feature-updates"></a>
 #### 機能改善
 
 ##### Load Balancer
@@ -528,8 +659,10 @@
 * レコードセットを作成できる最大数を追加しました。DNS Zone1つ当たり、レコードセットは最大5,000個まで作成できます。
 * レコードセット統計照会時、CNAMEレコードセットタイプはAレコードセットタイプとAAAAレコードセットタイプを一緒に照会するように修正しました。
 
-### 2019. 06. 25.
+<a id="june-25-2019"></a>
+### 2019. 06. 25. { #june-25-2019 }
 
+<a id="june-25-2019-release-of-new-products"></a>
 #### 新規サービスリリース
 
 ##### DNS Plus
@@ -537,8 +670,10 @@
 * DNS Plusは、ドメイン管理機能を提供するサービスです。
 * DNS Serverを簡単に設定できます。
 
-### 2019. 05. 30.
+<a id="may-30-2019"></a>
+### 2019. 05. 30. { #may-30-2019 }
 
+<a id="may-30-2019-feature-updates"></a>
 #### 機能改善
 
 ##### Load Balancer
@@ -547,16 +682,20 @@
     * IPを基盤にしたアクセス制御機能を、ロードバランサーで使用できます。
     * IPアクセス制御機能の詳細は、ユーザーガイドを参照してください。
 
-### 2019. 05. 28.
+<a id="may-28-2019"></a>
+### 2019. 05. 28. { #may-28-2019 }
 
+<a id="may-28-2019-feature-updates"></a>
 #### 機能変更
 
 ##### VPC
 
 - [韓国リージョン]ピアリング作成機能を再度使用できます。
 
-### 2019. 04. 25.
+<a id="april-25-2019"></a>
+### 2019. 04. 25. { #april-25-2019 }
 
+<a id="april-25-2019-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -566,8 +705,10 @@
     * IP 접근제어 기능에 대한 자세한 사항은 사용자가이드 문서를 참고해주세요.
     * 유선으로 설정 요청하신 제어 대상 IP 목록은 Default 라는 이름의 IP 접근제어 그룹에 자동 반영되었습니다.
 
-### 2018. 12. 27.
+<a id="december-27-2018"></a>
+### 2018. 12. 27. { #december-27-2018 }
 
+<a id="december-27-2018-feature-updates"></a>
 #### 기능 변경
 
 ##### VPC
@@ -575,14 +716,17 @@
 * 피어링 된 두 VPC 사이의 통신 시 패킷 플러딩이 발생할 가능성이 있어, 당분간 새로운 피어링 생성 기능을 제공하지 않습니다.
 	기존에 만들어진 피어링의 통신에는 문제가 없으며 피어링 생성을 제외한 나머지 기능은 그대로 제공됩니다.
 
-### 2018. 11. 27.
+<a id="november-27-2018"></a>
+### 2018. 11. 27. { #november-27-2018 }
 
+<a id="november-27-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 
 * 로드 밸런서에 리스너를 추가 생성하는 경우, 비활성화된 인스턴스에 추가된 인스턴스 멤버가 활성화된채 생성되는 버그를 수정하였습니다.
 
+<a id="november-27-2018-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -594,14 +738,17 @@
     * 자세한 사항은 사용자가이드 문서를 참고해주세요.
 
 
-### 2018. 09. 20.
+<a id="september-20-2018"></a>
+### 2018. 09. 20. { #september-20-2018 }
 
+<a id="september-20-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 
 * Load Balancer에 Member로 등록된 Instance를 삭제할 때 일부 Listener의 Member가 남아있는 문제를 수정했습니다.
 
+<a id="september-20-2018-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -609,14 +756,17 @@
 * 전용 로드밸런서 서비스가 추가되었습니다.
 * 전용 로드밸런서는 하드웨어 자원을 선점하여 생성되기에 1Gbps의 대역폭과 48만 동시세션을 지원합니다.
 
-### 2018. 08. 28.
+<a id="august-28-2018"></a>
+### 2018. 08. 28. { #august-28-2018 }
 
+<a id="august-28-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### VPC
 
 * 라우트가 존재하는 서브넷을 가진 VPC에 대해 삭제를 시도할 수 있는 문제를 수정했습니다.
 
+<a id="august-28-2018-feature-updates"></a>
 #### 기능 변경
 
 ##### VPC
@@ -633,14 +783,17 @@
 * Load Balancer의 Keepalive timeout 값을 설정할 수 있습니다.
 
 
-### 2018. 04. 24.
+<a id="april-24-2018"></a>
+### 2018. 04. 24. { #april-24-2018 }
 
+<a id="april-24-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### VPC
 
 * 피어링 시 로컬 VPC의 인스턴스에서 피어 VPC의 로드밸런서로 접속이 원활하지 않은 문제를 수정했습니다.
 
+<a id="april-24-2018-feature-updates"></a>
 #### 기능 개선
 
 ##### VPC
@@ -660,8 +813,10 @@
 * Keepalive Timeout을 5분으로 변경하였습니다.
 * Listener의 세션 제한값을 최대 60,000 까지 설정할 수 있습니다.
 
-### 2018. 03. 22.
+<a id="march-22-2018"></a>
+### 2018. 03. 22. { #march-22-2018 }
 
+<a id="march-22-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### VPC
@@ -670,14 +825,17 @@
 * 라우팅 정책을 추가할 때 기존 라우팅 정책의 타겟과 동일한 타겟을 입력할 수 있는 문제를 수정했습니다.
 * Floating IP가 연결된 인스턴스에서 간헐적으로 다른 서브넷에 위치한 인스턴스와 통신이 되지 않는 문제를 수정했습니다.
 
-### 2018. 02. 22.
+<a id="february-22-2018"></a>
+### 2018. 02. 22. { #february-22-2018 }
 
+<a id="february-22-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### VPC
 
 * Floating IP가 연결된 인스턴스에서 로컬 네트워크로 트래픽이 전달되지 않는 문제를 수정했습니다.
 
+<a id="february-22-2018-feature-updates"></a>
 #### 기능 개선
 
 ##### Network 기본 모델로 VPC를 도입했습니다.
@@ -690,22 +848,28 @@
 * 자세한 내용은 VPC Overview와 사용자 가이드를 참고해주시기 바랍니다.
 
 
-### 2017. 11. 23.
+<a id="november-23-2017"></a>
+### 2017. 11. 23. { #november-23-2017 }
 
+<a id="november-23-2017-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 * Load Balancer 생성시 리스너의 연결 제한값이 잘못 표기되는 현상을 수정하였습니다.
 
-### 2017. 10. 26.
+<a id="october-26-2017"></a>
+### 2017. 10. 26. { #october-26-2017 }
 
+<a id="october-26-2017-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 * Load Balancer 생성시 인증서가 등록되지 않는 버그가 수정되었습니다.
 
-### 2017. 09. 21.
+<a id="september-21-2017"></a>
+### 2017. 09. 21. { #september-21-2017 }
 
+<a id="september-21-2017-added-features"></a>
 #### 기능 추가
 
 ##### Public API 추가
@@ -713,34 +877,43 @@
 * Object Storage에 이어 Compute&Network 상품을 API를 이용해 관리할 수 있습니다.
 * 현재 제한적인 기능만 이용할 수 있으며, 추후 API 추가를 통해 기능이 확장되었습니다.
 
+<a id="september-21-2017-bug-fixes"></a>
 #### 버그 수정
 
 * Project에 Admin 권한이 없는 사용자가 보안 그룹(security group)을 수정할 수 없도록 수정되었습니다.
 * Project에 Admin 권한이 없는 사용자에게는 Network 메뉴가 노출되지 않도록 수정되었습니다.
 
-### 2017. 08. 24.
+<a id="august-24-2017"></a>
+### 2017. 08. 24. { #august-24-2017 }
 
+<a id="august-24-2017-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 * Load Balancer 서비스의 세션 지속성 항목이 제대로 표시되지 않던 버그가 수정되었습니다.
 
-### 2017. 04. 20.
+<a id="april-20-2017"></a>
+### 2017. 04. 20. { #april-20-2017 }
 
+<a id="april-20-2017-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * Listener에 인증서 파일 업로드시 간헐적으로 인증서 등록창이 사라지는 버그가 수정되었습니다.
 
 
-### 2017. 03. 23.
+<a id="march-23-2017"></a>
+### 2017. 03. 23. { #march-23-2017 }
 
+<a id="march-23-2017-bug-fixes"></a>
 #### 버그 수정
 ##### Floating IP
 * Floating IP 연결 팝업에서 "생성" 버튼이 노출되지 않는 문제가 수정되었습니다.
 
 
-### 2017. 02. 23.
+<a id="february-23-2017"></a>
+### 2017. 02. 23. { #february-23-2017 }
 
+<a id="february-23-2017-feature-updates"></a>
 #### 기능 개선/변경
 
 ##### Load Balancer
@@ -758,16 +931,20 @@
 	  * 인스턴스에 Floating IP를 붙일 때 대상이 되는 명칭을 기존 “포트”에서 “네트워크 인터페이스”로 변경합니다.
 
 
-### 2017. 01. 19.
+<a id="january-19-2017"></a>
+### 2017. 01. 19. { #january-19-2017 }
 
+<a id="january-19-2017-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * Load Balancer 생성시 연결 제한 설정이 적용되지 않는 문제를 수정하였습니다.
 
 
 
-### 2016. 12. 22.
+<a id="december-22-2016"></a>
+### 2016. 12. 22. { #december-22-2016 }
 
+<a id="december-22-2016-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
@@ -784,8 +961,10 @@
 
 
 
-### 2016. 12. 08.
+<a id="december-8-2016"></a>
+### 2016. 12. 08. { #december-8-2016 }
 
+<a id="december-8-2016-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
@@ -799,32 +978,40 @@
 
 
 
-### 2016. 11. 29.
+<a id="november-29-2016"></a>
+### 2016. 11. 29. { #november-29-2016 }
 
+<a id="november-29-2016-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * TERMINATED_HTTPS type의 Load Balancer 생성이 실패하던 문제를 수정하였습니다.
 
 
 
-### 2016. 11. 24.
+<a id="november-24-2016"></a>
+### 2016. 11. 24. { #november-24-2016 }
 
+<a id="november-24-2016-feature-updates"></a>
 #### 기능 개선/변경
 ##### Load Balancer
 * Load Balancer의 Listener별 세션 제한 값을 노출하도록 변경하였습니다.
 
+<a id="november-24-2016-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * 특정 Project에서 Load Balancer 생성 실패하던 문제를 수정하였습니다.
 
 
 
-### 2016. 08. 04.
+<a id="august-4-2016"></a>
+### 2016. 08. 04. { #august-4-2016 }
 
+<a id="august-4-2016-feature-updates"></a>
 #### 기능 개선/변경
 ##### Load Balancer
 * Load Balancer의 SSL offloading 기능을 추가하였습니다.
 
+<a id="august-4-2016-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * Load Balancer 제거 시 간헐적으로 정상 종료되지 않던 문제를 수정하였습니다.

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,7 +1,10 @@
-## Network > 릴리스 노트
+<a id="network-release-notes"></a>
+## Network > 릴리스 노트 { #network-release-notes }
 
-### 2026. 05. 27.
+<a id="may-27-2026"></a>
+### 2026. 05. 27. { #may-27-2026 }
 
+<a id="may-27-2026-added-features"></a>
 #### 기능 추가
 
 ##### Network Interface
@@ -14,6 +17,7 @@
 	* Load Balancer(DSR)는 한국(평촌) 리전과 한국(판교) 리전에서만 이용할 수 있습니다.
 * [Load Balancer(DSR) 콘솔 사용 가이드](/Network/Load%20Balancer(DSR)/ko/console-guide/)를 참고하세요.
 
+<a id="may-27-2026-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -26,21 +30,26 @@
     * 패킷이 통과한 네트워크 경로(VPC Local, Internet Gateway, VPN Gateway, VPC Peering, Region Peering, Project Peering, Service Gateway)를 정수 값으로 확인할 수 있습니다.
     * [Flow Log 개요](/Network/Flow%20Log/ko/overview/)를 참고하세요.
 
+<a id="may-27-2026-may-27-2026-feature-updates"></a>
 #### 기능 변경
 
 ##### VPC
 * 네트워크 서비스 연동 지원을 위해 VPC의 내부 트래픽 처리 방식이 일부 변경되었습니다. 신규 생성되는 VPC부터 적용됩니다.
 
-### 2026. 04. 14.
+<a id="april-14-2026"></a>
+### 2026. 04. 14. { #april-14-2026 }
 
+<a id="april-14-2026-added-features"></a>
 #### 기능 추가
 
 ##### DNS Plus
 *  API v2.0 추가
     * User Access Key 토큰을 지원합니다.
 
-### 2025. 11. 25.
+<a id="november-25-2025"></a>
+### 2025. 11. 25. { #november-25-2025 }
 
+<a id="november-25-2025-added-features"></a>
 #### 기능 추가
 
 ##### VPN Gateway
@@ -56,18 +65,22 @@
 * 리스너별 사용자 정의 응답 설정 기능이 추가되었습니다.
 * X-Forwarded-* 헤더 활성/비활성화 기능이 추가되었습니다.
 
+<a id="november-25-2025-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer 
 * 여러 개의 SSL 인증서 등록/관리 기능이 콘솔에서 지원됩니다. 
 
+<a id="november-25-2025-1"></a>
 #### 기능 변경
 
 ##### DNS Plus
 *  TXT 레코드 세트 타입의 레코드 값 최대 길이를 255 바이트에서 4096 바이트로 변경하였습니다.
 
-### 2025. 08. 26.
+<a id="august-26-2025"></a>
+### 2025. 08. 26. { #august-26-2025 }
 
+<a id="august-26-2025-added-features"></a>
 #### 기능 추가
 
 ##### VPN Gateway
@@ -83,8 +96,10 @@
 * 로드 밸런서의 CPU 사용량, 리스너 단위의 통계, 소켓 연결 상태 등의 지표를 Cloud Monitoring 서비스를 통해 확인할 수 있도록 추가되었습니다.
 
 
-### 2025. 05. 27.
+<a id="may-27-2025"></a>
+### 2025. 05. 27. { #may-27-2025 }
 
+<a id="may-27-2025-added-features"></a>
 #### 기능 추가
 
 ##### NAT Gateway
@@ -109,21 +124,26 @@
 ##### Flow Log
 * Region peering gateway, Project peering gateway, Colocation gateway, 로드 밸런서의 네트워크 인터페이스를 대상으로 Flow Log를 생성할 수 있도록 기능이 추가되었습니다.
 
+<a id="may-27-2025-feature-updates"></a>
 #### 기능 개선
 ##### Flow Log
 * Flow Log의 파일을 OBS에 저장할 때, 폴더와 파일 이름을 자유롭게 편집할 수 있도록 개선되었습니다.
 
 
-### 2025. 04. 29.
+<a id="april-29-2025"></a>
+### 2025. 04. 29. { #april-29-2025 }
 
+<a id="april-29-2025-feature-updates"></a>
 #### 기능 변경
 
 ##### DNS Plus
 * 레코드 세트 TTL의 최솟값을 1에서 10으로 변경하였습니다.
 
 
-### 2025. 03. 04.
+<a id="march-4-2025"></a>
+### 2025. 03. 04. { #march-4-2025 }
 
+<a id="march-4-2025-feature-updates"></a>
 #### 기능 개선
 
 ##### Service Gateway
@@ -142,8 +162,10 @@
 * 라우트의 CIDR, 게이트웨이 항목을 변경하는 기능이 추가되었습니다.
 
 
-### 2024. 11. 26.
+<a id="november-26-2024"></a>
+### 2024. 11. 26. { #november-26-2024 }
 
+<a id="november-26-2024-feature-updates"></a>
 #### 기능 개선
 
 ##### Peering Gateway
@@ -153,8 +175,10 @@
 * gzip 압축 기능이 추가되었습니다.
 * Flow Log가 지원하는 통계 제공 정보 항목 중에서 사용자가 원하는 항목만 선택하여 기록을 남길 수 있도록 개선되었습니다. 지원하는 통계 항목은 [Flowlog 개요](/Network/Flow%20Log/ko/overview/)를 참고하세요.
 
-### 2024. 08. 27.
+<a id="network-release-notes-1"></a>
+### 2024. 08. 27. { #network-release-notes-1 }
 
+<a id="network-release-notes-1-1"></a>
 #### 기능 추가
 
 ##### Flow Log
@@ -168,6 +192,7 @@
 * Diffie-Hellman groups 14,15,16,17,18,19,20,21,27,28을 지원합니다.
 
 
+<a id="network-release-notes-1-2"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -180,8 +205,10 @@
 * 멀티캐스트 도메인을 다른 프로젝트에 공유할 수 있도록 기능이 추가되었습니다. 다른 프로젝트에서 생성된 VPC 간에 멀티캐스트 통신을 할 수 있습니다.
 
 
-### 2024. 05. 28.
+<a id="may-28-2024"></a>
+### 2024. 05. 28. { #may-28-2024 }
 
+<a id="may-28-2024-added-features"></a>
 #### 기능 추가
 
 ##### Load Balancer
@@ -200,28 +227,35 @@
 ##### DNS Plus
 * GSLB 헬스 체크에서 헬스 체크 요청의 헤더, 헬스 체크 주기, 최대 응답 대기 시간, 최대 재시도 횟수 설정 기능이 추가되었습니다.
 
+<a id="may-28-2024-feature-updates"></a>
 #### 기능 개선
 
 ##### Service Gateway
 * 기본 정보 탭에 API 엔드포인트 도메인 항목이 추가되었습니다.
 
-### 2024. 03. 26.
+<a id="march-26-2024"></a>
+### 2024. 03. 26. { #march-26-2024 }
 
+<a id="march-26-2024-added-features"></a>
 #### 기능 추가
 
 ##### Transit Hub
 * Public API에 Transit Hub 관련 API가 추가되었습니다. [Transit Hub API 가이드](/Network/Transit%20Hub/ko/public-api/)를 참고하세요.
 
-### 2024. 03. 12.
+<a id="march-12-2024"></a>
+### 2024. 03. 12. { #march-12-2024 }
 
+<a id="march-12-2024-feature-updates"></a>
 #### 기능 개선
 
 ##### DNS Plus
 * SPF 레코드 세트 타입 지원이 중단되었습니다. TXT 레코드 세트 타입으로 대신 사용할 수 있습니다.
     * 상세 내용은 [[RFC 7208#section-14.1]](https://datatracker.ietf.org/doc/html/rfc7208#section-14.1)에서 확인할 수 있습니다.
 
-### 2024. 02. 27.
+<a id="february-27-2024"></a>
+### 2024. 02. 27. { #february-27-2024 }
 
+<a id="february-27-2024-added-features"></a>
 #### 기능 추가
 
 ##### Floating IP
@@ -231,6 +265,7 @@
 * 로드 밸런서 삭제 보호 기능이 추가되었습니다.
 * Public API에 L7 로드 밸런싱 관련 API가 추가되었습니다. [로드 밸런서 API 가이드](https://docs.nhncloud.com/ko/Network/Load%20Balancer/ko/public-api/)를 참고하세요.
 
+<a id="february-27-2024-feature-updates"></a>
 #### 기능 개선/변경
 
 ##### Private DNS
@@ -240,8 +275,10 @@
 ##### Transit Hub
 * 라우팅 룰 패킷 처리 방식에 패킷을 소멸시키는 BLACKHOLE이 추가되었습니다. 
 
-### 2023. 11. 28.
+<a id="november-28-2023"></a>
+### 2023. 11. 28. { #november-28-2023 }
 
+<a id="november-28-2023-added-features"></a>
 #### 기능 추가
 
 ##### Load Balancer
@@ -253,8 +290,10 @@
 * Private DNS 신규 서비스가 추가되었습니다. VPC마다 독립된 DNS를 구성할 수 있습니다. 
   * Private DNS는 한국(평촌) 리전과 한국(판교) 리전에서만 이용할 수 있습니다. 
 
-### 2023. 08. 29.
+<a id="august-29-2023"></a>
+### 2023. 08. 29. { #august-29-2023 }
 
+<a id="august-29-2023-added-features"></a>
 #### 기능 추가
 
 ##### Transit Hub
@@ -278,8 +317,10 @@
 
 * 한국(평촌) Public API가 출시되었습니다. [Network ACL API 가이드](https://docs.nhncloud.com/ko/Network/Network%20ACL/ko/public-api/)를 참고해 주시요.
 
-### 2023. 05. 30.
+<a id="may-30-2023"></a>
+### 2023. 05. 30. { #may-30-2023 }
 
+<a id="may-30-2023-feature-updates"></a>
 #### 기능 개선
 
 ##### Network Interface
@@ -288,8 +329,10 @@
     * 검색 기능이 추가되었습니다.
     * 장치 이름을 표시하도록 개선했습니다.
 
-### 2023. 03. 28.
+<a id="march-28-2023"></a>
+### 2023. 03. 28. { #march-28-2023 }
 
+<a id="march-28-2023-added-features"></a>
 #### 기능 추가
 
 ##### Traffic Mirroring
@@ -297,20 +340,24 @@
 * Traffic Mirroring 기능이 추가되었습니다. 패킷을 캡처하여 콘텐츠 보안, 위협 분석, 트러블 슈팅 등의 목적을 가진 감지 도구로 라우팅할 수 있습니다.
     * 트래픽 미러링은 한국(평촌) 리전과 한국(판교) 리전에서만 이용할 수 있습니다.
 
+<a id="march-28-2023-feature-updates"></a>
 #### 기능 개선 
 
 ##### VPC
 
 * Public API에 VPC 및 VPC Subnet API가 추가되었습니다. 자세한 사항은 [VPC API 사용자 가이드](https://docs.nhncloud.com/ko/Network/VPC/ko/public-api/)를 참고하세요. 
 
+<a id="march-28-2023-1"></a>
 #### 기능 변경
 
 ##### VPC, Floating IP, Security Groups, Load Balancer
 
 * API 엔드포인트 주소가 변경되었습니다.
 
-### 2023. 01. 31.
+<a id="january-31-2023"></a>
+### 2023. 01. 31. { #january-31-2023 }
 
+<a id="january-31-2023-feature-updates"></a>
 #### 기능 개선
 
 ##### Colocation Gateway
@@ -322,16 +369,20 @@
 * 동일 VPC 내의 서비스 게이트웨이만 통신이 가능한 제약 사항이 제거되었습니다. 
 * 피어링 게이트웨이, 코로케이션 게이트웨이를 경유하여 다른 VPC의 서비스 게이트웨이를 이용할 수 있습니다.
 
-### 2022. 11. 29.
+<a id="november-29-2022"></a>
+### 2022. 11. 29. { #november-29-2022 }
 
+<a id="november-29-2022-added-features"></a>
 #### 기능 추가
 
 ##### Peering Gateway
 
 * [한국 평촌/판교 리전] 피어링, 프로젝트 피어링, 리전 피어링에 라우트를 설정할 수 있는 기능이 추가되었습니다.
 
-### 2022. 10. 04.
+<a id="october-26-2022"></a>
+### 2022. 10. 04. { #october-26-2022 }
 
+<a id="october-26-2022-feature-updates"></a>
 #### 기능 개선
 
 ##### Service Gateway
@@ -339,16 +390,20 @@
 * 지원 서비스 추가
     * NCR
 
-### 2022. 07. 26.
+<a id="july-26-2022"></a>
+### 2022. 07. 26. { #july-26-2022 }
 
+<a id="july-26-2022-added-features"></a>
 #### 기능 추가
 
 ##### Load Balancer
 
 * 상태 확인 시 호스트 헤더의 필드값을 변경할 수 있는 기능이 추가되었습니다.
 
-### 2022. 06. 30.
+<a id="june-30-2022"></a>
+### 2022. 06. 30. { #june-30-2022 }
 
+<a id="june-30-2022-feature-updates"></a>
 #### 기능 개선
 
 ##### Service Gateway
@@ -356,8 +411,10 @@
 * 지원 서비스 추가
     * CloudTrail
 
-### 2022. 05. 24.
+<a id="may-24-2022"></a>
+### 2022. 05. 24. { #may-24-2022 }
 
+<a id="may-24-2022-added-features"></a>
 #### 기능 추가
 
 ##### Peering Gateway
@@ -374,8 +431,10 @@
 * [한국 판교 리전] NAT 게이트웨이 기능이 추가되었습니다.
 
 
-### 2022. 03. 29.
+<a id="march-29-2022"></a>
+### 2022. 03. 29. { #march-29-2022 }
 
+<a id="march-29-2022-added-features"></a>
 #### 기능 추가
 
 ##### VPC
@@ -385,8 +444,10 @@
 * 리전 간 피어링 기능이 추가되었습니다. 다른 리전에 생성된 두 개의 VPC를 연결할 수 있습니다.
     * 리전 간 피어링은 한국(평촌) 리전과 한국(판교) 리전에서만 이용할 수 있습니다.
 
-### 2022. 01. 18.
+<a id="january-18-2022"></a>
+### 2022. 01. 18. { #january-18-2022 }
 
+<a id="january-18-2022-added-features"></a>
 #### 기능 추가
 
 ##### VPC
@@ -399,14 +460,17 @@
 * 이중화를 위한 가상 IP 생성 기능이 추가되었습니다. 가상 IP로 사용할 IP를 선점하고, 라우팅 테이블에서 해당 IP로의 라우트를 추가할 수 있습니다.
 * 인스턴스를 게이트웨이/방화벽 등의 용도로 사용할 수 있도록 네트워크 인터페이스의 보안 설정을 해제하는 기능이 추가되었습니다.
 
+<a id="january-18-2022-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
 
 * TERMINATED_HTTPS 프로토콜을 사용하는 로드 밸런서에서 TLS 1.3 버전을 사용할 수 있도록 개선되었습니다.
 
-### 2021. 08. 24.
+<a id="august-24-2021"></a>
+### 2021. 08. 24. { #august-24-2021 }
 
+<a id="august-24-2021-added-features"></a>
 #### 기능 추가
 
 ##### DNS Plus
@@ -414,8 +478,10 @@
 * 레코드 세트 대량 생성 기능이 추가되었습니다.
 
 
-### 2021. 04. 27.
+<a id="april-27-2021"></a>
+### 2021. 04. 27. { #april-27-2021 }
 
+<a id="april-27-2021-added-features"></a>
 #### 기능 추가
 
 ##### NAT 인스턴스
@@ -427,8 +493,10 @@
 * [한국 평촌 리전] 물리 로드밸런서를 온라인으로 생성할 수 있습니다. 기존 로드밸런서 대비 변경사항은 [로드밸런서가이드](https://docs.toast.com/ko/Network/Load%20Balancer/ko/console-guide/#_19)를 참고하세요.
 
 
-### 2021. 03. 23.
+<a id="march-23-2021"></a>
+### 2021. 03. 23. { #march-23-2021 }
 
+<a id="march-23-2021-added-features"></a>
 #### 기능 추가
 
 ##### NAT 게이트웨이
@@ -441,8 +509,10 @@
 * [한국/일본/미국 리전] 새로 생성되는 로드밸런서의 기본 연결 제한 개수가 2,000에서 60,000으로 변경됩니다.
 
 
-### 2021. 02. 06.
+<a id="february-6-2021"></a>
+### 2021. 02. 06. { #february-6-2021 }
 
+<a id="february-6-2021-feature-updates"></a>
 #### 기능 변경
 
 ##### VPC
@@ -450,23 +520,29 @@
 * [한국 판교 리전] 라우팅 테이블의 기본 라우트(VPC 주소 영역 전체로의 로컬 라우트)가 적용되지 않는 문제를 수정했습니다. 기존에는 VPC 내의 서브넷이라도 같은 라우팅 테이블에 연결되어 있는 서브넷 간에만 통신이 가능했지만, 서로 다른 라우팅 테이블에 연결되어 있는 서브넷 간에도 통신이 가능합니다.
 
 
-### 2020. 11. 24.
+<a id="november-24-2020"></a>
+### 2020. 11. 24. { #november-24-2020 }
 
+<a id="november-24-2020-feature-updates"></a>
 #### 기능 추가
 
 ##### Network Interface
 * Network Interface 기능이 추가되었습니다.
 
-### 2020. 09. 22.
+<a id="september-22-2020"></a>
+### 2020. 09. 22. { #september-22-2020 }
 
+<a id="september-22-2020-feature-updates"></a>
 #### 기능 개선
 
 ##### DNS Plus
 
 * 레코드 세트 수정 시 레코드 세트 타입 수정이 가능하도록 개선되었습니다.
 
-### 2020. 08. 25.
+<a id="august-25-2020"></a>
+### 2020. 08. 25. { #august-25-2020 }
 
+<a id="august-25-2020-added-features"></a>
 #### 기능 추가
 
 ##### Network ACL
@@ -477,16 +553,20 @@
 
 * Public API v2가 IP 접근 제어 기능을 지원합니다. 자세한 사항은 [로드밸런서API가이드](https://docs.toast.com/ko/Network/Load%20Balancer/ko/public-api/#ip-acl)를 참고하세요.
 
-### 2020. 06. 23.
+<a id="june-23-2020"></a>
+### 2020. 06. 23. { #june-23-2020 }
 
+<a id="june-23-2020-features-updates"></a>
 #### 기능 변경
 
 ##### VPC
 * [한국/일본/미국 리전] 라우팅 테이블의 라우트 생성 창에서 게이트웨이 항목에 IP를 직접 입력하는 방식을 IP를 소유한 장치를 선택하는 방식으로 변경했습니다. 라우팅 테이블에 명시적으로 연결하지 않은 서브넷의 장치도 선택할 수 있습니다.
 * [한국/일본/미국 리전] 인터넷 게이트웨이 목록에서 IP 정보 대신 연결된 라우팅 테이블의 정보를 표시하도록 변경했습니다. 라우팅 테이블의 라우트 탭에서도 연결된 인터넷 게이트웨이의 이름이 표시됩니다.
 
-### 2020. 05. 26.
+<a id="may-26-2020"></a>
+### 2020. 05. 26. { #may-26-2020 }
 
+<a id="may-26-2020-feature-updates"></a>
 #### 기능 개선
 
 ##### VPC
@@ -501,8 +581,10 @@
 * Public API v2가 출시됩니다. Public API v2는 Openstack API와 호환됩니다.
 
 
-### 2020. 03. 24.
+<a id="march-24-2020"></a>
+### 2020. 03. 24. { #march-24-2020 }
 
+<a id="march-24-2020-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -510,16 +592,20 @@
 * Cert Manager 서비스를 통한 인증서 관리기능이 추가 되었습니다.
 * Cert Manager 서비스에 인증서를 등록하고 리스너에 해당 인증서를 연결하면 이메일로 인증서 만료일 알람을 받을 수 있습니다.
 
-### 2020. 02. 25.
+<a id="february-25-2020"></a>
+### 2020. 02. 25. { #february-25-2020 }
 
+<a id="february-25-2020-feature-updates"></a>
 #### 기능 개선
 
 ##### 보안 그룹(security group)
 
 * 보안 그룹 규칙에 "설명" 항목이 추가되었습니다. 보안 그룹 규칙별로 설명을 추가할 수 있습니다.
 
-### 2019. 12. 24.
+<a id="december-24-2019"></a>
+### 2019. 12. 24. { #december-24-2019 }
 
+<a id="december-24-2019-added-features"></a>
 #### 기능 추가
 
 ##### DNS Plus
@@ -529,27 +615,34 @@
 * Pool은 라우팅 규칙을 적용할 수 있는 최소 단위로 엔드포인트 서버를 그룹핑하는 요소입니다.
 * 주기적으로 Pool에 포함된 엔드포인트 서버에 헬스 체크를 수행하여 안정적인 서비스를 지원할 수 있습니다. 헬스 체크는 HTTP/HTTPS/TCP를 지원합니다.
 
+<a id="december-24-2019-feature-updates"></a>
 #### 기능 개선
 
 ##### DNS Plus
 
 * 레코드 세트 생성/수정 시 CNAME 레코드 세트 타입을 사용자의 GSLB 도메인을 선택하여 입력할 수 있도록 개선되었습니다.
 
-### 2019. 12. 17.
+<a id="december-17-2019"></a>
+### 2019. 12. 17. { #december-17-2019 }
 
+<a id="december-17-2019-feature-updates"></a>
 #### 기능 개선
 * [한국/일본/미국 리전] 인스턴스에 연결된 모든 네트워크 인터페이스에 각각 플로팅 IP를 연결할 수 있습니다.
 
-### 2019. 10. 29.
+<a id="october-29-2019"></a>
+### 2019. 10. 29. { #october-29-2019 }
 
+<a id="october-29-2019-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
 
 * [한국/일본 리전] 체인 인증서를 등록할 때 인증서 파일에 포함된 개별 인증서의 형식이 잘못된 경우, 웹콘솔을 통해 알리는 기능이 추가되었습니다.
 
-### 2019. 08. 27.
+<a id="august-27-2019"></a>
+### 2019. 08. 27. { #august-27-2019 }
 
+<a id="august-27-2019-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -562,8 +655,10 @@
 * 레코드 세트의 최대 생성 가능 개수를 추가했습니다. DNS Zone당 레코드 세트는 최대 5,000개까지 생성할 수 있습니다.
 * 레코드 세트 통계 조회 시 CNAME 레코드 세트 타입은 A 레코드 세트 타입과 AAAA 레코드 세트 타입을 같이 조회하도록 수정했습니다.
 
-### 2019. 06. 25.
+<a id="june-25-2019"></a>
+### 2019. 06. 25. { #june-25-2019 }
 
+<a id="june-25-2019-release-of-new-products"></a>
 #### 신규 상품 출시
 
 ##### DNS Plus
@@ -571,8 +666,10 @@
 * DNS Plus는 도메인 관리 기능을 제공하는 서비스입니다.
 * DNS 서버를 간편하게 설정할 수 있습니다.
 
-### 2019. 05. 30.
+<a id="may-30-2019"></a>
+### 2019. 05. 30. { #may-30-2019 }
 
+<a id="may-30-2019-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -581,16 +678,20 @@
     * IP를 기반으로 한 접근제어 기능을 Load Balancer에서 사용할 수 있습니다.
     * IP 접근 제어 기능에 대한 자세한 사항은 사용자 가이드 문서를 참고해주세요.
 
-### 2019. 05. 28.
+<a id="may-28-2019"></a>
+### 2019. 05. 28. { #may-28-2019 }
 
+<a id="may-28-2019-feature-updates"></a>
 #### 기능 변경
 
 ##### VPC
 
 * [한국 리전] 피어링 생성 기능을 다시 사용할 수 있습니다.
 
-### 2019. 04. 25.
+<a id="april-25-2019"></a>
+### 2019. 04. 25. { #april-25-2019 }
 
+<a id="april-25-2019-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -600,8 +701,10 @@
     * IP 접근제어 기능에 대한 자세한 사항은 사용자가이드 문서를 참고해주세요.
     * 유선으로 설정 요청하신 제어 대상 IP 목록은 Default 라는 이름의 IP 접근제어 그룹에 자동 반영되었습니다.
 
-### 2018. 12. 27.
+<a id="december-27-2018"></a>
+### 2018. 12. 27. { #december-27-2018 }
 
+<a id="december-27-2018-feature-updates"></a>
 #### 기능 변경
 
 ##### VPC
@@ -609,14 +712,17 @@
 * 피어링 된 두 VPC 사이의 통신 시 패킷 플러딩이 발생할 가능성이 있어, 당분간 새로운 피어링 생성 기능을 제공하지 않습니다.
 	기존에 만들어진 피어링의 통신에는 문제가 없으며 피어링 생성을 제외한 나머지 기능은 그대로 제공됩니다.
 
-### 2018. 11. 27.
+<a id="november-27-2018"></a>
+### 2018. 11. 27. { #november-27-2018 }
 
+<a id="november-27-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 
 * 로드 밸런서에 리스너를 추가 생성하는 경우, 비활성화된 인스턴스에 추가된 인스턴스 멤버가 활성화된채 생성되는 버그를 수정하였습니다.
 
+<a id="november-27-2018-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -628,14 +734,17 @@
     * 자세한 사항은 사용자가이드 문서를 참고해주세요.
 
 
-### 2018. 09. 20.
+<a id="september-20-2018"></a>
+### 2018. 09. 20. { #september-20-2018 }
 
+<a id="september-20-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 
 * Load Balancer에 Member로 등록된 Instance를 삭제할 때 일부 Listener의 Member가 남아있는 문제를 수정했습니다.
 
+<a id="september-20-2018-feature-updates"></a>
 #### 기능 개선
 
 ##### Load Balancer
@@ -643,14 +752,17 @@
 * 전용 로드밸런서 서비스가 추가되었습니다.
 * 전용 로드밸런서는 하드웨어 자원을 선점하여 생성되기에 1Gbps의 대역폭과 48만 동시세션을 지원합니다.
 
-### 2018. 08. 28.
+<a id="august-28-2018"></a>
+### 2018. 08. 28. { #august-28-2018 }
 
+<a id="august-28-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### VPC
 
 * 라우트가 존재하는 서브넷을 가진 VPC에 대해 삭제를 시도할 수 있는 문제를 수정했습니다.
 
+<a id="august-28-2018-feature-updates"></a>
 #### 기능 변경
 
 ##### VPC
@@ -667,14 +779,17 @@
 * Load Balancer의 Keepalive timeout 값을 설정할 수 있습니다.
 
 
-### 2018. 04. 24.
+<a id="april-24-2018"></a>
+### 2018. 04. 24. { #april-24-2018 }
 
+<a id="april-24-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### VPC
 
 * 피어링 시 로컬 VPC의 인스턴스에서 피어 VPC의 로드밸런서로 접속이 원활하지 않은 문제를 수정했습니다.
 
+<a id="april-24-2018-feature-updates"></a>
 #### 기능 개선
 
 ##### VPC
@@ -694,8 +809,10 @@
 * Keepalive Timeout을 5분으로 변경하였습니다.
 * Listener의 세션 제한값을 최대 60,000 까지 설정할 수 있습니다.
 
-### 2018. 03. 22.
+<a id="march-22-2018"></a>
+### 2018. 03. 22. { #march-22-2018 }
 
+<a id="march-22-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### VPC
@@ -704,14 +821,17 @@
 * 라우팅 정책을 추가할 때 기존 라우팅 정책의 타겟과 동일한 타겟을 입력할 수 있는 문제를 수정했습니다.
 * Floating IP가 연결된 인스턴스에서 간헐적으로 다른 서브넷에 위치한 인스턴스와 통신이 되지 않는 문제를 수정했습니다.
 
-### 2018. 02. 22.
+<a id="february-22-2018"></a>
+### 2018. 02. 22. { #february-22-2018 }
 
+<a id="february-22-2018-bug-fixes"></a>
 #### 버그 수정
 
 ##### VPC
 
 * Floating IP가 연결된 인스턴스에서 로컬 네트워크로 트래픽이 전달되지 않는 문제를 수정했습니다.
 
+<a id="february-22-2018-feature-updates"></a>
 #### 기능 개선
 
 ##### Network 기본 모델로 VPC를 도입했습니다.
@@ -724,22 +844,28 @@
 * 자세한 내용은 VPC Overview와 사용자 가이드를 참고해주시기 바랍니다.
 
 
-### 2017. 11. 23.
+<a id="november-23-2017"></a>
+### 2017. 11. 23. { #november-23-2017 }
 
+<a id="november-23-2017-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 * Load Balancer 생성시 리스너의 연결 제한값이 잘못 표기되는 현상을 수정하였습니다.
 
-### 2017. 10. 26.
+<a id="october-26-2017"></a>
+### 2017. 10. 26. { #october-26-2017 }
 
+<a id="october-26-2017-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 * Load Balancer 생성시 인증서가 등록되지 않는 버그가 수정되었습니다.
 
-### 2017. 09. 21.
+<a id="september-21-2017"></a>
+### 2017. 09. 21. { #september-21-2017 }
 
+<a id="september-21-2017-added-features"></a>
 #### 기능 추가
 
 ##### Public API 추가
@@ -747,34 +873,43 @@
 * Object Storage에 이어 Compute&Network 상품을 API를 이용해 관리할 수 있습니다.
 * 현재 제한적인 기능만 이용할 수 있으며, 추후 API 추가를 통해 기능이 확장되었습니다.
 
+<a id="september-21-2017-bug-fixes"></a>
 #### 버그 수정
 
 * Project에 Admin 권한이 없는 사용자가 보안 그룹(security group)을 수정할 수 없도록 수정되었습니다.
 * Project에 Admin 권한이 없는 사용자에게는 Network 메뉴가 노출되지 않도록 수정되었습니다.
 
-### 2017. 08. 24.
+<a id="august-24-2017"></a>
+### 2017. 08. 24. { #august-24-2017 }
 
+<a id="august-24-2017-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
 * Load Balancer 서비스의 세션 지속성 항목이 제대로 표시되지 않던 버그가 수정되었습니다.
 
-### 2017. 04. 20.
+<a id="april-20-2017"></a>
+### 2017. 04. 20. { #april-20-2017 }
 
+<a id="april-20-2017-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * Listener에 인증서 파일 업로드시 간헐적으로 인증서 등록창이 사라지는 버그가 수정되었습니다.
 
 
-### 2017. 03. 23.
+<a id="march-23-2017"></a>
+### 2017. 03. 23. { #march-23-2017 }
 
+<a id="march-23-2017-bug-fixes"></a>
 #### 버그 수정
 ##### Floating IP
 * Floating IP 연결 팝업에서 "생성" 버튼이 노출되지 않는 문제가 수정되었습니다.
 
 
-### 2017. 02. 23.
+<a id="february-23-2017"></a>
+### 2017. 02. 23. { #february-23-2017 }
 
+<a id="february-23-2017-feature-updates"></a>
 #### 기능 개선/변경
 
 ##### Load Balancer
@@ -792,16 +927,20 @@
 	  * 인스턴스에 Floating IP를 붙일 때 대상이 되는 명칭을 기존 “포트”에서 “네트워크 인터페이스”로 변경합니다.
 
 
-### 2017. 01. 19.
+<a id="january-19-2017"></a>
+### 2017. 01. 19. { #january-19-2017 }
 
+<a id="january-19-2017-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * Load Balancer 생성시 연결 제한 설정이 적용되지 않는 문제를 수정하였습니다.
 
 
 
-### 2016. 12. 22.
+<a id="december-22-2016"></a>
+### 2016. 12. 22. { #december-22-2016 }
 
+<a id="december-22-2016-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
@@ -818,8 +957,10 @@
 
 
 
-### 2016. 12. 08.
+<a id="december-8-2016"></a>
+### 2016. 12. 08. { #december-8-2016 }
 
+<a id="december-8-2016-bug-fixes"></a>
 #### 버그 수정
 
 ##### Load Balancer
@@ -833,32 +974,40 @@
 
 
 
-### 2016. 11. 29.
+<a id="november-29-2016"></a>
+### 2016. 11. 29. { #november-29-2016 }
 
+<a id="november-29-2016-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * TERMINATED_HTTPS type의 Load Balancer 생성이 실패하던 문제를 수정하였습니다.
 
 
 
-### 2016. 11. 24.
+<a id="november-24-2016"></a>
+### 2016. 11. 24. { #november-24-2016 }
 
+<a id="november-24-2016-feature-updates"></a>
 #### 기능 개선/변경
 ##### Load Balancer
 * Load Balancer의 Listener별 세션 제한 값을 노출하도록 변경하였습니다.
 
+<a id="november-24-2016-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * 특정 Project에서 Load Balancer 생성 실패하던 문제를 수정하였습니다.
 
 
 
-### 2016. 08. 04.
+<a id="august-4-2016"></a>
+### 2016. 08. 04. { #august-4-2016 }
 
+<a id="august-4-2016-feature-updates"></a>
 #### 기능 개선/변경
 ##### Load Balancer
 * Load Balancer의 SSL offloading 기능을 추가하였습니다.
 
+<a id="august-4-2016-bug-fixes"></a>
 #### 버그 수정
 ##### Load Balancer
 * Load Balancer 제거 시 간헐적으로 정상 종료되지 않던 문제를 수정하였습니다.


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `beta` |
| Scope | 1 doc(s) scanned · 3 file(s) changed |
| Self-verify | ⚠️ 14 mismatch(es) remain |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/115/ |
| Generated | 2026-07-11T14:33:35 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`beta`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork%2Fblob%2Fbeta%2Fko%2Frelease-notes.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork%2Fpull%2F142&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork%2Fpull%2F142&ref=beta&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | — | ✅ |
| `en/release-notes.md` | 1 | 18 | 0 | 0 | 13 | 0 | 0 | — | ⚠️ 13 |
| `ja/release-notes.md` | 5 | 9 | 0 | 0 | 2 | 0 | 0 | — | ⚠️ 1 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `en/release-notes.md`:
  - extra_in_target (ko#None/en#61)
  - extra_in_target (ko#None/en#62)
  - extra_in_target (ko#None/en#63)
  - extra_in_target (ko#None/en#64)
  - extra_in_target (ko#None/en#65)
  - extra_in_target (ko#None/en#66)
  - extra_in_target (ko#None/en#67)
  - extra_in_target (ko#None/en#75)
  - extra_in_target (ko#None/en#76)
  - extra_in_target (ko#None/en#77)
  - extra_in_target (ko#None/en#78)
  - extra_in_target (ko#None/en#79)
  - extra_in_target (ko#None/en#116)
- `ja/release-notes.md`:
  - extra_in_target (ko#None/ja#68)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Network`